### PR TITLE
Forecasting: spell out MAPE/RMSE in accuracy tooltips

### DIFF
--- a/pages/forecasting.py
+++ b/pages/forecasting.py
@@ -161,19 +161,20 @@ def render_result(result, history_by_target: dict):
                 "MAPE (average error %)",
                 f"{tf.cv_metrics.mape:.1%}",
                 help=(
-                    "On average, how far off past forecasts were from what actually happened, "
-                    "as a percentage. Lower is better — e.g. 10% means forecasts were typically "
-                    "off by about a tenth of the actual value."
+                    "MAPE = Mean Absolute Percentage Error. On average, how far off past "
+                    "forecasts were from what actually happened, as a percentage. Lower is "
+                    "better — e.g. 10% means forecasts were typically off by about a tenth of "
+                    "the actual value."
                 ),
             )
             col2.metric(
                 "RMSE (typical error size)",
                 f"{tf.cv_metrics.rmse:.2f}",
                 help=(
-                    "The typical size of the error in the same units as your data (e.g. "
-                    "conversions or currency), with bigger misses counted extra heavily. "
-                    "Lower is better; compare it to the size of your usual numbers to judge "
-                    "whether it's a big deal."
+                    "RMSE = Root Mean Square Error. The typical size of the error in the same "
+                    "units as your data (e.g. conversions or currency), with bigger misses "
+                    "counted extra heavily. Lower is better; compare it to the size of your "
+                    "usual numbers to judge whether it's a big deal."
                 ),
             )
             col3.metric(


### PR DESCRIPTION
## Summary
- The MAPE/RMSE accuracy metrics on the forecasting page already had short plain-language labels ("average error %" / "typical error size") and explanatory tooltips, but never spelled out what the acronyms themselves stand for.
- Adds "MAPE = Mean Absolute Percentage Error" and "RMSE = Root Mean Square Error" to the start of each tooltip.

## Test plan
- [x] `python -m ast` syntax check passes
- [x] Change is a string-only edit inside existing `st.metric(..., help=...)` calls — no logic touched