### PR TITLE
Forecasting: fix history/future split for weekly/monthly, flag stale results

### DIFF
--- a/forecast_utils/cleaning.py
+++ b/forecast_utils/cleaning.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 _ENCODINGS_TO_TRY = ["utf-8-sig", "utf-8", "cp1252", "latin-1"]
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 _CURRENCY_CHARS = "$€£¥₹"
 _DATE_NAME_HINTS = ("date", "dt", "day", "period", "time", "week", "month")
@@ -182,7 +183,19 @@ def best_effort_parse_dates(series: pd.Series) -> tuple[pd.Series, float, bool, 
     interpretations parse equally well but disagree on the actual date for
     at least one row (e.g. "03/04/2024" — 3 April or 4 March?), which no
     amount of heuristics can resolve from the data alone.
+
+    Strict ISO 8601 (YYYY-MM-DD) is never ambiguous — the year always leads,
+    so there's no day/month order to guess — but naively re-parsing it with
+    dayfirst=True can still "succeed" by reinterpreting the month and day
+    fields, which would otherwise falsely trip the ambiguity check on
+    perfectly clean data. Short-circuit those out before the heuristic.
     """
+    non_null = series.dropna().astype(str)
+    if not non_null.empty and non_null.str.match(_ISO_DATE_RE).all():
+        parsed = pd.to_datetime(series, format="%Y-%m-%d", errors="coerce")
+        rate = parsed.notna().sum() / len(non_null)
+        return parsed, rate, False, False
+
     parsed_mf, rate_mf = _date_parse_success_rate(series, dayfirst=False)
     parsed_df, rate_df = _date_parse_success_rate(series, dayfirst=True)
 

--- a/pages/forecasting.py
+++ b/pages/forecasting.py
@@ -153,6 +153,25 @@ _PERIOD_NOUNS = {
     ForecastGranularity.MONTHLY: "month",
 }
 
+_GRANULARITY_FREQ = {
+    ForecastGranularity.DAILY: "D",
+    ForecastGranularity.WEEKLY: "W-MON",
+    ForecastGranularity.MONTHLY: "MS",
+}
+
+
+def last_resampled_date(dates, granularity):
+    """The last *complete* historical bucket at the chosen granularity.
+
+    `dates` are raw (e.g. daily) actual dates. For weekly/monthly granularity
+    these don't line up with the engine's own resampled bins — comparing a
+    raw last-actual date directly against the resampled forecast series would
+    misclassify a trailing partial bucket as "future". Mirrors the engine's
+    own resample call so the history/future split lines up exactly.
+    """
+    freq = _GRANULARITY_FREQ[granularity]
+    return pd.Series(0, index=pd.to_datetime(dates)).resample(freq).sum().index.max()
+
 
 def period_noun(granularity, count: int) -> str:
     """e.g. period_noun(ForecastGranularity.DAILY, 30) -> 'days'."""
@@ -228,9 +247,9 @@ def render_target_forecast(target_name, tf, history_by_target: dict, granularity
     fc_df = pd.DataFrame(chart_data["forecast"])
     band_df = pd.DataFrame(chart_data["expected_range"])
 
-    last_actual_date = hist_df["ds"].max()
+    last_actual_date = last_resampled_date(hist_df["ds"], granularity)
     future_table = fc_df.merge(band_df, on="ds")
-    future_table = future_table[future_table["ds"] > last_actual_date].copy()
+    future_table = future_table[pd.to_datetime(future_table["ds"]) > last_actual_date].copy()
     future_table = future_table.rename(
         columns={
             "ds": "Date",
@@ -246,7 +265,7 @@ def render_target_forecast(target_name, tf, history_by_target: dict, granularity
     n_periods = len(future_table)
     noun = period_noun(granularity, n_periods)
 
-    hist_fitted = fc_df[fc_df["ds"] <= last_actual_date].reset_index(drop=True)
+    hist_fitted = fc_df[pd.to_datetime(fc_df["ds"]) <= last_actual_date].reset_index(drop=True)
     offset = comparison_offset_periods(granularity, n_periods, comparison_mode)
     start_idx = len(hist_fitted) - offset
     end_idx = start_idx + n_periods
@@ -350,7 +369,19 @@ def render_target_forecast(target_name, tf, history_by_target: dict, granularity
     st.caption(chart_data["chart_caption"])
 
     with st.expander("How well does the model fit the past?"):
-        residual_df = hist_df.merge(fc_df, on="ds", how="inner")
+        # Aggregate raw actuals to the chosen granularity (summed, matching how
+        # the engine itself aggregates targets) before comparing to the fitted
+        # series — otherwise daily actuals barely overlap weekly/monthly bins.
+        freq = _GRANULARITY_FREQ[granularity]
+        resampled_actuals = (
+            hist_df.assign(ds=pd.to_datetime(hist_df["ds"]))
+            .set_index("ds")["y"]
+            .resample(freq)
+            .sum()
+            .reset_index()
+        )
+        resampled_actuals["ds"] = resampled_actuals["ds"].dt.strftime("%Y-%m-%d")
+        residual_df = resampled_actuals.merge(fc_df, on="ds", how="inner")
         residual_df["residual"] = residual_df["y"] - residual_df["yhat"]
         st.caption(
             "Actual minus forecast for every historical date — bars above zero mean the "
@@ -830,6 +861,29 @@ if regressors:
     future_regressors_df = pd.DataFrame(future_parts)
 
 st.divider()
+
+# A signature of every knob that affects the *fit* (deliberately excluding
+# comparison_mode, which is applied purely at render time and updates live
+# without needing a re-run). Compared against whatever signature produced
+# the currently-stored result, so a stale display can be flagged instead of
+# silently showing an outdated forecast after the user tweaks a setting.
+current_config_signature = (
+    date_col, conversions_col, revenue_col, granularity_label, int(periods),
+    growth_logistic, cap, floor, seasonality_multiplicative, tuple(sorted(regressors)),
+    interval_width, cv_horizon_periods,
+    tuple(map(tuple, holidays_df.fillna("").to_numpy().tolist())),
+    weather_enabled, weather_location,
+)
+
+if (
+    st.session_state.get("forecast_result") is not None
+    and st.session_state.get("forecast_config_signature") != current_config_signature
+):
+    st.warning(
+        "Your settings have changed since this forecast was generated — click "
+        "'Run forecast' below to update the chart and table."
+    )
+
 run_clicked = st.button("Run forecast", type="primary")
 
 if run_clicked:
@@ -913,6 +967,7 @@ if run_clicked:
                         )
                     st.session_state["forecast_result"] = result
                     st.session_state["forecast_history"] = history_by_target
+                    st.session_state["forecast_config_signature"] = current_config_signature
 
 if st.session_state.get("forecast_result") is not None:
     render_result(

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,0 +1,270 @@
+"""Unit tests for forecast_utils/cleaning.py — pure functions, no Streamlit
+or first-order-engine required, so these run fast and everywhere.
+"""
+import io
+
+import pandas as pd
+import pytest
+
+from forecast_utils.cleaning import (
+    best_effort_parse_dates,
+    clean_numeric_string,
+    clean_uploaded_dataframe,
+    drop_empty_rows_and_columns,
+    finalize_for_fit,
+    normalize_columns,
+    read_csv_robust,
+    suggest_date_column,
+    suggest_numeric_columns,
+)
+
+
+class _FakeUpload:
+    """Minimal stand-in for a Streamlit UploadedFile."""
+
+    def __init__(self, content: bytes):
+        self._content = content
+
+    def getvalue(self):
+        return self._content
+
+
+# ---------------------------------------------------------------------------
+# clean_numeric_string
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (100, 100.0),
+        (12.5, 12.5),
+        ("100", 100.0),
+        ("$1,234.56", 1234.56),
+        ("1.234,56", 1234.56),  # EU: dot=thousands, comma=decimal
+        ("1,234.56", 1234.56),  # US: comma=thousands, dot=decimal
+        ("12,5", 12.5),  # bare EU decimal comma
+        ("1,234", 1234.0),  # bare thousands comma
+        ("12%", 12.0),
+        ("(100)", -100.0),
+        ("-50", -50.0),
+        ("+50", 50.0),
+        ("€ 99.90", 99.90),
+        ("", None),
+        ("n/a", None),
+        (None, None),
+    ],
+)
+def test_clean_numeric_string(raw, expected):
+    result = clean_numeric_string(raw)
+    if expected is None:
+        assert result is None
+    else:
+        assert result == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# normalize_columns
+# ---------------------------------------------------------------------------
+def test_normalize_columns_names_blank_headers():
+    from forecast_utils.cleaning import CleaningReport
+
+    df = pd.DataFrame([[1, 2]], columns=["", "Unnamed: 1"])
+    report = CleaningReport()
+    cleaned = normalize_columns(df, report)
+    assert list(cleaned.columns) == ["column_1", "column_2"]
+    assert report.notes  # something was logged
+
+
+def test_normalize_columns_dedupes_duplicates():
+    from forecast_utils.cleaning import CleaningReport
+
+    df = pd.DataFrame([[1, 2, 3]], columns=["date", "revenue", "revenue"])
+    report = CleaningReport()
+    cleaned = normalize_columns(df, report)
+    assert list(cleaned.columns) == ["date", "revenue", "revenue_1"]
+    assert any("Duplicate" in w for w in report.warnings)
+
+
+def test_normalize_columns_trims_whitespace():
+    from forecast_utils.cleaning import CleaningReport
+
+    df = pd.DataFrame([[1]], columns=["  Date  "])
+    report = CleaningReport()
+    cleaned = normalize_columns(df, report)
+    assert list(cleaned.columns) == ["Date"]
+
+
+# ---------------------------------------------------------------------------
+# drop_empty_rows_and_columns
+# ---------------------------------------------------------------------------
+def test_drop_empty_rows_and_columns():
+    from forecast_utils.cleaning import CleaningReport
+
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", None, "2024-01-03"],
+            "value": [1, None, 3],
+            "empty_col": [None, None, None],
+        }
+    )
+    report = CleaningReport()
+    cleaned = drop_empty_rows_and_columns(df, report)
+    assert "empty_col" not in cleaned.columns
+    assert len(cleaned) == 2
+    assert any("empty column" in n for n in report.notes)
+    assert any("empty row" in n for n in report.notes)
+
+
+# ---------------------------------------------------------------------------
+# best_effort_parse_dates
+# ---------------------------------------------------------------------------
+def test_best_effort_parse_dates_unambiguous_iso():
+    s = pd.Series(["2024-01-01", "2024-01-02", "2024-01-03"])
+    parsed, rate, dayfirst_used, ambiguous = best_effort_parse_dates(s)
+    assert rate == 1.0
+    assert not ambiguous
+    assert parsed.notna().all()
+
+
+def test_best_effort_parse_dates_flags_genuine_ambiguity():
+    # 03/04/2024 and 04/03/2024 parse fine both ways but disagree
+    s = pd.Series(["03/04/2024", "04/03/2024", "05/06/2024"])
+    _, rate, _, ambiguous = best_effort_parse_dates(s)
+    assert rate == 1.0
+    assert ambiguous
+
+
+def test_best_effort_parse_dates_unambiguous_when_only_one_side_parses():
+    # "13" can't be a month, so only the day-first reading is even valid —
+    # pandas' own format inference gets there before our dayfirst flag does,
+    # so both branches agree on the same (correct) date.
+    s = pd.Series(["13/01/2024", "14/01/2024"])
+    parsed, rate, _, ambiguous = best_effort_parse_dates(s)
+    assert rate == 1.0
+    assert not ambiguous
+    assert parsed.tolist() == [pd.Timestamp("2024-01-13"), pd.Timestamp("2024-01-14")]
+
+
+# ---------------------------------------------------------------------------
+# read_csv_robust
+# ---------------------------------------------------------------------------
+def test_read_csv_robust_sniffs_semicolon_delimiter():
+    csv_text = "date;value\n2024-01-01;10\n2024-01-02;20\n"
+    df, report = read_csv_robust(_FakeUpload(csv_text.encode("utf-8")))
+    assert df is not None
+    assert list(df.columns) == ["date", "value"]
+    assert len(df) == 2
+    assert any("auto-detected delimiter" in n for n in report.notes)
+
+
+def test_read_csv_robust_handles_comma_normally():
+    csv_text = "date,value\n2024-01-01,10\n2024-01-02,20\n"
+    df, report = read_csv_robust(_FakeUpload(csv_text.encode("utf-8")))
+    assert df is not None
+    assert list(df.columns) == ["date", "value"]
+    assert report.ok
+
+
+def test_read_csv_robust_empty_file_errors():
+    df, report = read_csv_robust(_FakeUpload(b""))
+    assert df is None
+    assert report.errors
+
+
+def test_read_csv_robust_latin1_fallback():
+    csv_text = "date,label\n2024-01-01,caf\xe9\n"  # 'café' in latin-1
+    df, report = read_csv_robust(_FakeUpload(csv_text.encode("latin-1")))
+    assert df is not None
+    assert df["label"].iloc[0] == "café"
+    assert any("decoded as" in n for n in report.notes)
+
+
+# ---------------------------------------------------------------------------
+# suggest_date_column / suggest_numeric_columns
+# ---------------------------------------------------------------------------
+def test_suggest_date_and_numeric_columns():
+    df = pd.DataFrame(
+        {
+            "Date": ["2024-01-01", "2024-01-02", "2024-01-03"],
+            "Conversions": ["10", "20", "30"],
+            "Notes": ["a", "b", "c"],
+        }
+    )
+    assert suggest_date_column(df) == "Date"
+    assert "Conversions" in suggest_numeric_columns(df, exclude=["Date"])
+    assert "Notes" not in suggest_numeric_columns(df, exclude=["Date"])
+
+
+# ---------------------------------------------------------------------------
+# finalize_for_fit
+# ---------------------------------------------------------------------------
+def test_finalize_for_fit_drops_unparseable_dates_and_coerces_numbers():
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "not-a-date", "2024-01-03", "2024-01-04"],
+            "revenue": ["$1,000.50", "200", "$3,000.00", "4000"],
+        }
+    )
+    final_df, report = finalize_for_fit(df, "date", ["revenue"])
+    assert final_df is not None
+    assert len(final_df) == 3  # the bad-date row is dropped
+    assert final_df["revenue"].tolist() == [1000.50, 3000.00, 4000.0]
+    assert any("couldn't be parsed" in w for w in report.warnings)
+
+
+def test_finalize_for_fit_gates_on_minimum_rows():
+    df = pd.DataFrame({"date": ["2024-01-01"], "revenue": ["100"]})
+    final_df, report = finalize_for_fit(df, "date", ["revenue"], min_rows=2)
+    assert final_df is None
+    assert report.errors
+    assert not report.ok
+
+
+def test_finalize_for_fit_reports_ambiguous_dates():
+    df = pd.DataFrame(
+        {
+            "date": ["03/04/2024", "04/03/2024", "05/06/2024"],
+            "revenue": ["100", "200", "300"],
+        }
+    )
+    final_df, report = finalize_for_fit(df, "date", ["revenue"])
+    assert final_df is not None
+    assert any("ambiguous dates" in w for w in report.warnings)
+
+
+def test_finalize_for_fit_flags_uncoercible_numbers_without_dropping_row():
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02"],
+            "revenue": ["100", "not-a-number"],
+        }
+    )
+    final_df, report = finalize_for_fit(df, "date", ["revenue"])
+    assert final_df is not None
+    assert len(final_df) == 2  # row kept, value just becomes NaN
+    assert pd.isna(final_df["revenue"].iloc[1])
+    assert any("couldn't be read as a number" in w for w in report.warnings)
+
+
+# ---------------------------------------------------------------------------
+# clean_uploaded_dataframe (structural pass end-to-end)
+# ---------------------------------------------------------------------------
+def test_clean_uploaded_dataframe_end_to_end():
+    df = pd.DataFrame(
+        {
+            "": [None, None, None],
+            "Date ": ["2024-01-01", "2024-01-02", "2024-01-03"],
+            "Revenue": ["100", "200", "300"],
+        }
+    )
+    cleaned = clean_uploaded_dataframe(df)
+    assert "column_1" not in cleaned.df.columns  # fully-empty column dropped, not renamed
+    assert "Date" in cleaned.df.columns
+    assert cleaned.suggested_date_col == "Date"
+    assert "Revenue" in cleaned.suggested_numeric_cols
+
+
+def test_clean_uploaded_dataframe_all_empty_rows_errors():
+    df = pd.DataFrame({"a": [None, None], "b": [None, None]})
+    cleaned = clean_uploaded_dataframe(df)
+    assert not cleaned.report.ok
+    assert cleaned.df.empty

--- a/tests/test_forecasting.py
+++ b/tests/test_forecasting.py
@@ -5,6 +5,8 @@ Requires `first-order-engine` (and its `prophet`/`cmdstan` backend) to be
 installed, per requirements.txt. Skipped if that's not available, since
 compiling cmdstan needs a C++ toolchain that not every dev machine has.
 """
+import datetime
+import random
 from pathlib import Path
 
 import pytest
@@ -14,6 +16,27 @@ pytest.importorskip("foe", reason="first-order-engine not installed")
 from streamlit.testing.v1 import AppTest  # noqa: E402
 
 PAGE = str(Path(__file__).resolve().parent.parent / "pages" / "forecasting.py")
+
+
+def _synthetic_daily_csv(n_days: int = 500, seed: int = 1) -> bytes:
+    """A deterministic daily conversions/revenue CSV, long enough to fit
+    weekly/monthly granularity and a year-over-year comparison."""
+    rng = random.Random(seed)
+    lines = ["date,conversions,revenue"]
+    d = datetime.date(2023, 1, 1)
+    for i in range(n_days):
+        conv = 20 + i * 0.05 + rng.uniform(-3, 3)
+        rev = conv * 18 + rng.uniform(-20, 20)
+        lines.append(f"{d.isoformat()},{conv:.1f},{rev:.2f}")
+        d += datetime.timedelta(days=1)
+    return "\n".join(lines).encode("utf-8")
+
+
+def _upload_and_map(at: AppTest, csv_bytes: bytes) -> AppTest:
+    """Upload the synthetic CSV and run once so column-mapping widgets exist."""
+    at.get("file_uploader")[0].upload("data.csv", csv_bytes, "text/csv")
+    at.run(timeout=30)
+    return at
 
 
 def test_loads_without_upload():
@@ -35,3 +58,77 @@ def test_demo_data_runs_full_pipeline():
     tab_labels = [t.label for t in at.tabs]
     assert "Forecast: Conversions" in tab_labels
     assert "Forecast: Revenue" in tab_labels
+
+
+def test_upload_weekly_granularity_matches_requested_horizon():
+    """Regression test: weekly/monthly granularity used to miscount a
+    trailing partial historical bucket as an extra forecast period (e.g.
+    "next 9 weeks" for an 8-week request) because the history/future cutoff
+    was computed from raw daily dates instead of the resampled series."""
+    at = AppTest.from_file(PAGE)
+    at.run(timeout=30)
+    _upload_and_map(at, _synthetic_daily_csv())
+
+    granularity = next(r for r in at.radio if r.label == "Granularity")
+    granularity.set_value("weekly").run(timeout=30)
+    periods = next(n for n in at.number_input if "ahead to forecast" in n.label)
+    periods.set_value(8).run(timeout=30)
+
+    run_button = next(b for b in at.button if b.label == "Run forecast")
+    run_button.click().run(timeout=90)
+
+    assert not at.exception
+    total_metric = next(m for m in at.metric if m.label.startswith("Total forecast"))
+    assert total_metric.label == "Total forecast, next 8 weeks"
+    accuracy_metric = next(m for m in at.metric if m.label == "Accuracy checked over")
+    assert accuracy_metric.value == "8 weeks"
+
+
+def test_upload_single_target_revenue_only():
+    """Forecasting revenue without conversions should produce exactly one
+    tab (plus the report tab), and the Full report tab shouldn't choke on
+    only having one target to combine."""
+    at = AppTest.from_file(PAGE)
+    at.run(timeout=30)
+    _upload_and_map(at, _synthetic_daily_csv(n_days=120))
+
+    forecast_conversions = next(c for c in at.checkbox if c.label == "Forecast conversions")
+    forecast_conversions.set_value(False).run(timeout=30)
+    forecast_revenue = next(c for c in at.checkbox if c.label == "Forecast revenue")
+    forecast_revenue.set_value(True).run(timeout=30)
+
+    run_button = next(b for b in at.button if b.label == "Run forecast")
+    run_button.click().run(timeout=90)
+
+    assert not at.exception
+    tab_labels = [t.label for t in at.tabs]
+    assert tab_labels == ["Forecast: Revenue", "📄 Full report"]
+
+    # The Full report tab's combined CSV/markdown shouldn't error with a
+    # single target.
+    download_labels = [b.label for b in at.get("download_button")]
+    assert "Download combined forecast as CSV" in download_labels
+    assert "Download full report (Markdown)" in download_labels
+
+
+def test_settings_change_after_run_shows_staleness_warning():
+    """Regression test: changing a fit-affecting setting (e.g. horizon)
+    after a forecast has already run used to leave the old chart/table
+    displayed with no indication it no longer matches the current settings."""
+    at = AppTest.from_file(PAGE)
+    at.run(timeout=30)
+    _upload_and_map(at, _synthetic_daily_csv())
+
+    run_button = next(b for b in at.button if b.label == "Run forecast")
+    run_button.click().run(timeout=90)
+    assert not at.exception
+    assert not [w for w in at.warning if "settings have changed" in w.value]
+
+    periods = next(n for n in at.number_input if "ahead to forecast" in n.label)
+    periods.set_value(15).run(timeout=30)
+
+    stale_warnings = [w for w in at.warning if "settings have changed" in w.value]
+    assert stale_warnings, "expected a staleness warning after changing the horizon"
+    # The old result (30 days) should still be the one on screen, untouched.
+    total_metric = next(m for m in at.metric if m.label.startswith("Total forecast"))
+    assert total_metric.label == "Total forecast, next 30 days"


### PR DESCRIPTION
## Summary
- **Root cause fix**: the history/future cutoff was computed from raw (daily) actual dates, then compared directly against the engine's resampled forecast series. For weekly/monthly granularity these dates don't line up, so a trailing partial historical bucket was miscounted as a future period — inflating the forecast horizon by one (e.g. "next 9 weeks" for an 8-week request) and throwing off the total-forecast and comparison-delta numbers. Fixed by resampling the actual dates the same way the engine does before computing the cutoff.
- Same root cause made the "How well does the model fit the past?" residuals chart nearly empty for weekly/monthly granularity (daily actual dates almost never matched resampled forecast dates). Fixed by aggregating actuals to the chosen granularity before comparing to the fitted series.
- **Staleness banner**: changing granularity, horizon, or any other fit-affecting setting after a forecast has already run doesn't retrigger a refit until "Run forecast" is clicked again (refitting is expensive, so this is by design) — but the page gave no indication the displayed chart/table was now stale. A warning now appears above the button whenever live settings differ from the ones that produced the currently-shown result.

## Tests added
- `tests/test_cleaning.py`: unit tests for `forecast_utils/cleaning.py`'s pure functions (numeric/date coercion, header normalization, delimiter/encoding sniffing, the min-rows gate) — no Streamlit or first-order-engine needed. Writing these surfaced a real bug: perfectly clean ISO 8601 dates could get falsely flagged as "ambiguous" whenever every day-component happened to be ≤ 12 (re-parsing with `dayfirst=True` reinterprets the month/day fields instead of leaving an unambiguous year-leading format alone). Fixed by short-circuiting to a direct `%Y-%m-%d` parse whenever every value already matches that strict pattern.
- `tests/test_forecasting.py`: regression tests for each bug fixed above (weekly-granularity horizon count, single-target Full report export, staleness warning appearing/disappearing correctly).

## Test plan
- [x] `pytest tests/` passes (43 tests)
- [x] Verified via AppTest: switching to weekly granularity + 8-period horizon now shows "Total forecast, next 8 weeks" (was "next 9 weeks" before the fix)
- [x] Verified via a headless browser pass: the residuals chart is fully populated at weekly granularity (previously near-empty), and the staleness banner appears correctly when changing a setting without re-running
