### PR TITLE
Disambiguate bare EU thousands-dot notation in numeric cleaning

### DIFF
--- a/forecast_utils/cleaning.py
+++ b/forecast_utils/cleaning.py
@@ -259,8 +259,19 @@ def clean_numeric_string(value) -> float | None:
             s = s.replace(",", ".")
         else:
             s = s.replace(",", "")
-    # dot-only strings are left as-is (either a plain decimal or thousands
-    # dots handled by the comma/dot combo branch above)
+    elif has_dot and not has_comma:
+        # Ambiguous: "1.234" (EU thousands) vs "1.234" (a precise decimal).
+        # Mirror the comma heuristic: a single dot with exactly 1-2 trailing
+        # digits reads as a decimal point and is left alone; three trailing
+        # digits (or multiple dots, e.g. "1.234.567") reads as EU thousands
+        # grouping and the dot(s) are stripped.
+        parts = s.split(".")
+        if len(parts) == 2 and len(parts[1]) in (1, 2):
+            pass
+        elif len(parts) >= 2 and all(len(p) == 3 for p in parts[1:]):
+            s = s.replace(".", "")
+        # otherwise (e.g. 3+ trailing digits that aren't a clean thousands
+        # grouping) leave as a plain decimal — the safer default.
 
     try:
         num = float(s)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -43,6 +43,11 @@ class _FakeUpload:
         ("1,234.56", 1234.56),  # US: comma=thousands, dot=decimal
         ("12,5", 12.5),  # bare EU decimal comma
         ("1,234", 1234.0),  # bare thousands comma
+        ("1.234", 1234.0),  # bare EU thousands dot
+        ("1.234.567", 1234567.0),  # bare EU multi-thousands dot
+        ("12.5", 12.5),  # plain US/decimal dot, unaffected
+        ("99.90", 99.90),  # two trailing digits stays a decimal
+        ("1.5", 1.5),  # one trailing digit stays a decimal
         ("12%", 12.0),
         ("(100)", -100.0),
         ("-50", -50.0),


### PR DESCRIPTION
## Summary
- `clean_numeric_string` previously left dot-only strings untouched, so bare EU thousands notation without a decimal comma (e.g. `"1.234"` meaning 1,234) was misparsed as the decimal `1.234`.
- Added a dot-only disambiguation heuristic mirroring the existing comma-only one: a single dot with 1-2 trailing digits is treated as a decimal point (`"12.5"`, `"99.90"` unaffected); three trailing digits, or multiple dots (`"1.234.567"`), is treated as EU thousands grouping and the dot(s) are stripped.

## Test plan
- [x] Added `clean_numeric_string` cases in `tests/test_cleaning.py` for bare EU thousands (`"1.234"` → 1234.0), multi-thousands (`"1.234.567"` → 1234567.0), and regression cases confirming plain decimals (`"12.5"`, `"99.90"`, `"1.5"`) are unaffected.
- [x] `pytest tests/test_cleaning.py` — 39 passed.
