### PR TITLE
Fix column-mapping gate rejecting real datasets when both targets checked

### DIFF
--- a/pages/forecasting.py
+++ b/pages/forecasting.py
@@ -600,16 +600,33 @@ with col_a:
 with col_b:
     forecast_revenue = st.checkbox("Forecast revenue", value=False)
 
-numeric_candidates = [c for c in cleaned.suggested_numeric_cols if c != date_col] or [
-    c for c in all_columns if c != date_col
-]
+numeric_candidates = [c for c in all_columns if c != date_col]
+suggested_numeric = [c for c in cleaned.suggested_numeric_cols if c != date_col]
 
 conversions_col = None
 revenue_col = None
 if forecast_conversions:
-    conversions_col = st.selectbox("Conversions column", numeric_candidates, key="conversions_col_select")
+    default_conv = suggested_numeric[0] if suggested_numeric else (numeric_candidates[0] if numeric_candidates else None)
+    conversions_col = st.selectbox(
+        "Conversions column",
+        numeric_candidates,
+        index=numeric_candidates.index(default_conv) if default_conv in numeric_candidates else 0,
+        key="conversions_col_select",
+    )
 if forecast_revenue:
-    revenue_col = st.selectbox("Revenue column", numeric_candidates, key="revenue_col_select")
+    # Default to a *different* column than conversions when picking revenue's
+    # suggestion, so checking both doesn't default them onto the same column
+    # (which real datasets often only offer one strong numeric candidate for,
+    # since the suggestion heuristic requires an 80%+ clean-parse rate).
+    remaining_suggested = [c for c in suggested_numeric if c != conversions_col]
+    remaining_candidates = [c for c in numeric_candidates if c != conversions_col]
+    default_rev = (remaining_suggested or remaining_candidates or numeric_candidates or [None])[0]
+    revenue_col = st.selectbox(
+        "Revenue column",
+        numeric_candidates,
+        index=numeric_candidates.index(default_rev) if default_rev in numeric_candidates else 0,
+        key="revenue_col_select",
+    )
 
 if not forecast_conversions and not forecast_revenue:
     st.error("Select at least one of 'Forecast conversions' / 'Forecast revenue'.")


### PR DESCRIPTION
## Summary
- Reported bug: uploading a real dataset and checking both "Forecast conversions" and "Forecast revenue" produced an error saying conversions/revenue must be different columns, even though the file has two distinct numeric columns.
- Root cause: `numeric_candidates` for both the "Conversions column" and "Revenue column" dropdowns was restricted to `cleaned.suggested_numeric_cols`, which only includes columns with an 80%+ clean-parse rate. Real-world data commonly has one column (e.g. a messier revenue export) that misses that bar, so both dropdowns ended up offering just the single surviving column — forcing an identical selection that the conversions-must-differ-from-revenue check then rejected.
- Fix: always offer every non-date column as a selectable candidate for both dropdowns; the suggestion heuristic is now only used to pick sensible, distinct default selections (falling back to any non-colliding column when the suggestions don't offer two).

## Test plan
- [x] Reproduced the bug directly: confirmed `suggest_numeric_columns` returns only `['conversions']` for a synthetic real-world-shaped CSV where ~1/3 of the revenue column's values are `"n/a"` (33% below the 80% clean-parse threshold).
- [x] Ran an `AppTest` against `pages/forecasting.py` with that CSV and both targets checked: on `main`, both dropdowns defaulted to `conversions` and the equality error fired; with this fix, dropdowns offer both `conversions` and `revenue`, default to different columns, and no error is shown.
- [x] `pytest tests/test_cleaning.py` — 39 passed (unaffected by this change).
